### PR TITLE
Add SPA routing support for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,22 @@
     <meta name="twitter:site" content="@lovable_dev" />
     <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
     <script>
+      // GitHub Pages SPA redirect handler
+      // Restores the proper URL after redirect from 404.html
+      (function() {
+        var l = window.location;
+        if (l.search && l.search.indexOf('?p=') === 0) {
+          var decoded = l.search.slice(3).split('&q=');
+          var path = decoded[0].replace(/~and~/g, '&');
+          var query = decoded[1] ? ('?' + decoded[1].replace(/~and~/g, '&')) : '';
+          window.history.replaceState(null, null,
+            l.pathname.slice(0, -1) + (path ? '/' + decodeURIComponent(path) : '') +
+            decodeURIComponent(query) + l.hash
+          );
+        }
+      })();
+    </script>
+    <script>
       // Prevent flash of incorrect theme
       (function() {
         const stored = localStorage.getItem('theme');

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Redirecting...</title>
+    <script>
+      // GitHub Pages SPA redirect workaround
+      // This script stores the current path and redirects to index.html
+      // The index.html will then restore the correct URL
+      var pathSegmentsToKeep = 1; // Keep '/resto-radar-reviews-hub' segment
+      var l = window.location;
+      var redirectPath = l.pathname.split('/').slice(0, 1 + pathSegmentsToKeep).join('/') + '/?p=' +
+        encodeURIComponent(l.pathname.slice(1).split('/').slice(pathSegmentsToKeep).join('/').replace(/&/g, '~and~')) +
+        (l.search ? '&q=' + encodeURIComponent(l.search.slice(1).replace(/&/g, '~and~')) : '') +
+        l.hash;
+      l.replace(redirectPath);
+    </script>
+  </head>
+  <body>
+    <p>Redirecting...</p>
+  </body>
+</html>


### PR DESCRIPTION
- Add 404.html that redirects to index.html while preserving the path
- Add redirect handler script in index.html to restore proper URLs
- Fixes 404 errors when directly navigating to routes on GitHub Pages

https://claude.ai/code/session_01QfbhtgqeyDP2UVKZL6SJ9d